### PR TITLE
fix: expose types export condition before runtime entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- Move the package export `types` condition before `import`/`require`.
- Removes the build/install warning that the `types` condition is unreachable.

## Validation

- `npm run test:ci`
- `npm run build`
- `npm pack --dry-run --json`
